### PR TITLE
Fix(?) missing new lines in bulk_new_agent_notification.ftl

### DIFF
--- a/common/src/main/webapp/WEB-INF/freemarker/notifications/profiles/bulk_new_agent_notification.ftl
+++ b/common/src/main/webapp/WEB-INF/freemarker/notifications/profiles/bulk_new_agent_notification.ftl
@@ -13,7 +13,8 @@
 * ${rel.studentMember.fullName}<#--
 --><#if rel.replacesRelationships?has_content><#--
 --> (previous <@fmt.p number=rel.replacesRelationships?size singular=relationshipType.agentRole shownumber=false /> <#list rel.replacesRelationships as replaced>${replaced.agentName}<#if replaced_has_next>, </#if></#list>)<#--
---></#if>
+-->
+</#if>
 </#list>
 
 <#if previouslyScheduledDate?has_content>


### PR DESCRIPTION
As shown in the screenshot, the list of students in the notification does not have any new lines after each entry. This PR fixes that, I think. 

<img width="1038" alt="Screenshot 2019-08-07 at 13 17 05" src="https://user-images.githubusercontent.com/278086/62622278-e3465580-b915-11e9-9701-8781fe9e2d9f.png">
