### PR TITLE
Add a user setting to disable pre-filling new assignments

### DIFF
--- a/common/src/main/scala/uk/ac/warwick/tabula/commands/home/UserSettingsCommand.scala
+++ b/common/src/main/scala/uk/ac/warwick/tabula/commands/home/UserSettingsCommand.scala
@@ -28,6 +28,7 @@ class UserSettingsCommand(val user: CurrentUser, val settings: UserSettings) ext
   self: UserSettingsServiceComponent =>
 
   var alertsSubmission: String = settings.alertsSubmission
+  var newAssignmentSettings: String = settings.newAssignmentSettings
   var weekNumberingSystem: String = settings.weekNumberingSystem
   var bulkEmailSeparator: String = settings.bulkEmailSeparator
   var profilesDefaultView: String = settings.profilesDefaultView
@@ -40,6 +41,7 @@ class UserSettingsCommand(val user: CurrentUser, val settings: UserSettings) ext
 
   override def applyInternal(): UserSettings = transactional() {
     settings.alertsSubmission = alertsSubmission
+    settings.newAssignmentSettings = newAssignmentSettings
     settings.weekNumberingSystem = if (weekNumberingSystem.hasText) weekNumberingSystem else null
     settings.bulkEmailSeparator = bulkEmailSeparator
     settings.profilesDefaultView = profilesDefaultView
@@ -77,6 +79,7 @@ trait UserSettingsDescription extends Describable[UserSettings] {
     d.properties(
       "user" -> user.apparentId,
       "alertsSubmission" -> result.alertsSubmission,
+      "newAssignmentSettings" -> result.newAssignmentSettings,
       "hiddenIntros" -> result.hiddenIntros,
       "weekNumberingSystem" -> result.weekNumberingSystem,
       "bulkEmailSeparator" -> result.bulkEmailSeparator,

--- a/common/src/main/scala/uk/ac/warwick/tabula/data/model/UserSettings.scala
+++ b/common/src/main/scala/uk/ac/warwick/tabula/data/model/UserSettings.scala
@@ -27,6 +27,10 @@ class UserSettings extends GeneratedId with SettingsMap with HasNotificationSett
 
   def alertsSubmission_=(alert: String): Unit = settings += (Settings.AlertsSubmission -> alert)
 
+  def newAssignmentSettings: String = getStringSetting(Settings.NewAssignmentSettings).getOrElse(NewAssignmentPrefill)
+
+  def newAssignmentSettings_=(prefill: String): Unit = settings += (Settings.NewAssignmentSettings) -> prefill
+
   def hiddenIntros: Seq[String] = getStringSeqSetting(Settings.HiddenIntros).getOrElse(Nil)
 
   def hiddenIntros_=(hiddenIntro: Seq[String]): Unit = settings += (Settings.HiddenIntros -> hiddenIntro)
@@ -93,6 +97,9 @@ object UserSettings {
   val AlertsNoteworthySubmissions = "lateSubmissions"
   val AlertsNoSubmissions = "none"
 
+  val NewAssignmentPrefill = "restoreRecent"
+  val NewAssignmentNothing = "none"
+
   val DefaultBulkEmailSeparator = ";"
 
   val DefaultProfilesDefaultView = "gadget"
@@ -101,6 +108,7 @@ object UserSettings {
 
   object Settings {
     val AlertsSubmission = "alertsSubmission"
+    val NewAssignmentSettings = "newAssignmentSettings"
     val HiddenIntros = "hiddenIntros"
     val WeekNumberingSystem = "weekNumberSystem"
     val BulkEmailSeparator = "bulkEmailSeparator"

--- a/common/src/test/scala/uk/ac/warwick/tabula/services/UserSettingsServiceTest.scala
+++ b/common/src/test/scala/uk/ac/warwick/tabula/services/UserSettingsServiceTest.scala
@@ -15,6 +15,7 @@ class UserSettingsServiceTest extends AppContextTestBase {
     val userSettings = new UserSettings
     userSettings.userId = "cuscav"
     userSettings.alertsSubmission = UserSettings.AlertsNoteworthySubmissions
+    userSettings.newAssignmentSettings = UserSettings.NewAssignmentPrefill
 
     withUser("cuscav") {
       service.save(currentUser, userSettings)
@@ -22,6 +23,7 @@ class UserSettingsServiceTest extends AppContextTestBase {
 
     service.getByUserId("cuscav") should be('defined)
     service.getByUserId("cuscav").get.alertsSubmission should be(UserSettings.AlertsNoteworthySubmissions)
+    service.getByUserId("cuscav").get.newAssignmentSettings should be(UserSettings.NewAssignmentPrefill)
 
     // If we save a new empty user settings, we don't overwrite anything existing
     withUser("cuscav") {
@@ -30,5 +32,6 @@ class UserSettingsServiceTest extends AppContextTestBase {
 
     service.getByUserId("cuscav") should be('defined)
     service.getByUserId("cuscav").get.alertsSubmission should be(UserSettings.AlertsNoteworthySubmissions)
+    service.getByUserId("cuscav").get.newAssignmentSettings should be(UserSettings.NewAssignmentPrefill)
   }
 }

--- a/web/src/main/scala/uk/ac/warwick/tabula/web/controllers/cm2/admin/assignments/AddAssignmentDetailsController.scala
+++ b/web/src/main/scala/uk/ac/warwick/tabula/web/controllers/cm2/admin/assignments/AddAssignmentDetailsController.scala
@@ -40,8 +40,9 @@ class AddAssignmentDetailsController extends AbstractAssignmentController
   def form(@ModelAttribute("command") form: CreateAssignmentDetailsCommand, @PathVariable academicYear: AcademicYear): Mav = {
     val prefillSetting = userSettingsService.getByUserId(user.apparentId).map(_.newAssignmentSettings).getOrElse(UserSettings.NewAssignmentPrefill)
 
-    prefillSetting match {
-      case UserSettings.NewAssignmentNothing => form.prefillFromRecent = false
+    form.prefillFromRecent = prefillSetting match {
+      case UserSettings.NewAssignmentNothing => false
+      case _ => form.prefillFromRecent
     }
 
     form.prefillFromRecentAssignment()

--- a/web/src/main/scala/uk/ac/warwick/tabula/web/controllers/cm2/admin/assignments/AddAssignmentDetailsController.scala
+++ b/web/src/main/scala/uk/ac/warwick/tabula/web/controllers/cm2/admin/assignments/AddAssignmentDetailsController.scala
@@ -38,6 +38,12 @@ class AddAssignmentDetailsController extends AbstractAssignmentController
 
   @RequestMapping
   def form(@ModelAttribute("command") form: CreateAssignmentDetailsCommand, @PathVariable academicYear: AcademicYear): Mav = {
+    val prefillSetting = userSettingsService.getByUserId(user.apparentId).map(_.newAssignmentSettings).getOrElse(UserSettings.NewAssignmentPrefill)
+
+    prefillSetting match {
+      case UserSettings.NewAssignmentNothing => form.prefillFromRecent = false
+    }
+
     form.prefillFromRecentAssignment()
     showForm(form, academicYear)
   }

--- a/web/src/main/scala/uk/ac/warwick/tabula/web/controllers/home/UserSettingsController.scala
+++ b/web/src/main/scala/uk/ac/warwick/tabula/web/controllers/home/UserSettingsController.scala
@@ -82,6 +82,7 @@ class UserSettingsController extends BaseController {
 
 case class JSONUserSettings(
   alertsSubmission: String,
+  newAssignmentSettings: String,
   weekNumberingSystem: String,
   bulkEmailSeparator: String,
   profilesDefaultView: String
@@ -91,6 +92,7 @@ object JSONUserSettings {
   def apply(u: UserSettings): JSONUserSettings = {
     JSONUserSettings(
       alertsSubmission = u.alertsSubmission,
+      newAssignmentSettings = u.newAssignmentSettings,
       weekNumberingSystem = u.weekNumberingSystem,
       bulkEmailSeparator = u.bulkEmailSeparator,
       profilesDefaultView = u.profilesDefaultView

--- a/web/src/main/webapp/WEB-INF/freemarker/usersettings/form.ftl
+++ b/web/src/main/webapp/WEB-INF/freemarker/usersettings/form.ftl
@@ -21,6 +21,17 @@
           No alerts
         </@bs3form.radio>
       </@bs3form.labelled_form_group>
+
+      <@bs3form.labelled_form_group path="newAssignmentSettings" labelText="New assignment settings">
+        <@bs3form.radio>
+          <@f.radiobutton path="newAssignmentSettings" value="restoreRecent" />
+          Pre-fill fields from a recently created assignment.
+        </@bs3form.radio>
+        <@bs3form.radio>
+          <@f.radiobutton path="newAssignmentSettings" value="none" />
+          Do not pre-fill anything.
+        </@bs3form.radio>
+      </@bs3form.labelled_form_group>
     </#if>
 
     <@bs3form.labelled_form_group path="weekNumberingSystem" labelText="Week numbering system">

--- a/web/src/main/webapp/WEB-INF/freemarker/usersettings/form.ftl
+++ b/web/src/main/webapp/WEB-INF/freemarker/usersettings/form.ftl
@@ -25,11 +25,11 @@
       <@bs3form.labelled_form_group path="newAssignmentSettings" labelText="New assignment settings">
         <@bs3form.radio>
           <@f.radiobutton path="newAssignmentSettings" value="restoreRecent" />
-          Pre-fill fields from a recently created assignment.
+          Pre-fill fields from a recently created assignment
         </@bs3form.radio>
         <@bs3form.radio>
           <@f.radiobutton path="newAssignmentSettings" value="none" />
-          Do not pre-fill anything.
+          Do not pre-fill anything
         </@bs3form.radio>
       </@bs3form.labelled_form_group>
     </#if>


### PR DESCRIPTION
This PR adds a new user setting which allows users to permanently disable Tabula's pre-fill function when creating new assignments. The default behaviour should be as before, but if a user changes this setting, Tabula should never pre-fill new assignment settings. 

![image](https://user-images.githubusercontent.com/278086/64031015-94b85f80-cb3f-11e9-8539-d8eea6ed9b60.png)
