### PR TITLE
Add optional academicYear parameter to member assignments API

### DIFF
--- a/api/src/main/scala/uk/ac/warwick/tabula/api/web/controllers/coursework/assignments/MemberAssignmentsController.scala
+++ b/api/src/main/scala/uk/ac/warwick/tabula/api/web/controllers/coursework/assignments/MemberAssignmentsController.scala
@@ -2,7 +2,7 @@ package uk.ac.warwick.tabula.api.web.controllers.coursework.assignments
 
 import org.springframework.stereotype.Controller
 import org.springframework.validation.Errors
-import org.springframework.web.bind.annotation.{ModelAttribute, PathVariable, RequestMapping}
+import org.springframework.web.bind.annotation.{ModelAttribute, PathVariable, RequestMapping, RequestParam}
 import uk.ac.warwick.tabula.api.web.controllers.ApiController
 import uk.ac.warwick.tabula.api.web.helpers.StudentAssignmentInfoToJsonConverter
 import uk.ac.warwick.tabula.commands.coursework.assignments.StudentCourseworkCommand.StudentAssignments
@@ -10,6 +10,7 @@ import uk.ac.warwick.tabula.commands.{Appliable, MemberOrUser}
 import uk.ac.warwick.tabula.commands.coursework.assignments.StudentCourseworkFullScreenCommand
 import uk.ac.warwick.tabula.data.model.Member
 import MemberAssignmentsController._
+import uk.ac.warwick.tabula.AcademicYear
 import uk.ac.warwick.tabula.web.Mav
 import uk.ac.warwick.tabula.web.views.{JSONErrorView, JSONView}
 
@@ -28,8 +29,9 @@ trait GetMemberAssignmentsApi {
   self: ApiController with StudentAssignmentInfoToJsonConverter =>
 
   @ModelAttribute("getAssignmentsCommand")
-  def command(@PathVariable member: Member): ViewMemberAssignmentsCommand =
-    StudentCourseworkFullScreenCommand(MemberOrUser(member))
+  def command(@PathVariable member: Member, @RequestParam(required = false) academicYear: AcademicYear): ViewMemberAssignmentsCommand = {
+    StudentCourseworkFullScreenCommand(MemberOrUser(member), Option(academicYear))
+  }
 
   @RequestMapping(method = Array(GET), produces = Array("application/json"))
   def list(@ModelAttribute("getAssignmentsCommand") command: ViewMemberAssignmentsCommand, errors: Errors): Mav = {

--- a/common/src/main/scala/uk/ac/warwick/tabula/commands/coursework/assignments/StudentCourseworkFullScreenCommand.scala
+++ b/common/src/main/scala/uk/ac/warwick/tabula/commands/coursework/assignments/StudentCourseworkFullScreenCommand.scala
@@ -6,12 +6,12 @@ import uk.ac.warwick.tabula.data.model.Assignment
 import uk.ac.warwick.tabula.permissions.Permissions
 import uk.ac.warwick.tabula.services.{AssessmentMembershipServiceComponent, AssessmentServiceComponent, AutowiringAssessmentMembershipServiceComponent, AutowiringAssessmentServiceComponent}
 import uk.ac.warwick.tabula.system.permissions.{PermissionsChecking, RequiresPermissionsChecking}
-import uk.ac.warwick.tabula.{AutowiringFeaturesComponent, FeaturesComponent}
+import uk.ac.warwick.tabula.{AcademicYear, AutowiringFeaturesComponent, FeaturesComponent}
 import uk.ac.warwick.userlookup.User
 
 object StudentCourseworkFullScreenCommand {
-  def apply(memberOrUser: MemberOrUser): Appliable[StudentAssignments] =
-    new StudentCourseworkFullScreenCommandInternal(memberOrUser)
+  def apply(memberOrUser: MemberOrUser, academicYearOption: Option[AcademicYear] = None): Appliable[StudentAssignments] =
+    new StudentCourseworkFullScreenCommandInternal(memberOrUser, academicYearOption)
       with ComposableCommand[StudentAssignments]
       with StudentCourseworkFullScreenCommandPermissions
       with AutowiringAssessmentServiceComponent
@@ -21,19 +21,19 @@ object StudentCourseworkFullScreenCommand {
       with ReadOnly with Unaudited
 }
 
-class StudentCourseworkFullScreenCommandInternal(val memberOrUser: MemberOrUser) extends StudentCourseworkCommandInternal
-  with StudentCourseworkFullScreenCommandState {
+class StudentCourseworkFullScreenCommandInternal(val memberOrUser: MemberOrUser, val academicYearOption: Option[AcademicYear])
+  extends StudentCourseworkCommtandInternal with StudentCourseworkFullScreenCommandState {
 
   self: AssessmentServiceComponent with
     AssessmentMembershipServiceComponent with
     FeaturesComponent with
     StudentCourseworkCommandHelper =>
 
-  override lazy val overridableAssignmentsWithFeedback: Seq[Assignment] = assessmentService.getAssignmentsWithFeedback(memberOrUser.usercode)
+  override lazy val overridableAssignmentsWithFeedback: Seq[Assignment] = assessmentService.getAssignmentsWithFeedback(memberOrUser.usercode, academicYearOption)
 
-  override lazy val overridableEnrolledAssignments: Seq[Assignment] = assessmentMembershipService.getEnrolledAssignments(memberOrUser.asUser, None)
+  override lazy val overridableEnrolledAssignments: Seq[Assignment] = assessmentMembershipService.getEnrolledAssignments(memberOrUser.asUser, academicYearOption)
 
-  override lazy val overridableAssignmentsWithSubmission: Seq[Assignment] = assessmentService.getAssignmentsWithSubmission(memberOrUser.usercode)
+  override lazy val overridableAssignmentsWithSubmission: Seq[Assignment] = assessmentService.getAssignmentsWithSubmission(memberOrUser.usercode, academicYearOption)
 
   override val usercode: String = memberOrUser.usercode
 

--- a/common/src/main/scala/uk/ac/warwick/tabula/commands/coursework/assignments/StudentCourseworkFullScreenCommand.scala
+++ b/common/src/main/scala/uk/ac/warwick/tabula/commands/coursework/assignments/StudentCourseworkFullScreenCommand.scala
@@ -22,7 +22,7 @@ object StudentCourseworkFullScreenCommand {
 }
 
 class StudentCourseworkFullScreenCommandInternal(val memberOrUser: MemberOrUser, val academicYearOption: Option[AcademicYear])
-  extends StudentCourseworkCommtandInternal with StudentCourseworkFullScreenCommandState {
+  extends StudentCourseworkCommandInternal with StudentCourseworkFullScreenCommandState {
 
   self: AssessmentServiceComponent with
     AssessmentMembershipServiceComponent with


### PR DESCRIPTION
This PR adds an optional `academicYear` request parameter to the API endpoint for listing all of a member's assignments so that e.g.
```
GET https://tabula.warwick.ac.uk/api/v1/member/:universityId/assignments?academicYear=18%2F19
```` 
only returns assignments for the `18/19` academic year rather than _all_ assignments for that member. Without `academicYear` specified, the endpoint should behave as before. 