### PR TITLE
Add API endpoint for retrieving small group event attendance

### DIFF
--- a/api/src/main/scala/uk/ac/warwick/tabula/api/web/controllers/groups/ModuleSmallGroupSetsController.scala
+++ b/api/src/main/scala/uk/ac/warwick/tabula/api/web/controllers/groups/ModuleSmallGroupSetsController.scala
@@ -2,7 +2,6 @@ package uk.ac.warwick.tabula.api.web.controllers.groups
 
 import javax.servlet.http.HttpServletResponse
 import javax.validation.Valid
-
 import org.joda.time.DateTime
 import org.springframework.http.{HttpStatus, MediaType}
 import org.springframework.stereotype.Controller
@@ -12,7 +11,7 @@ import uk.ac.warwick.tabula.JavaImports._
 import uk.ac.warwick.tabula.api.commands.JsonApiRequest
 import uk.ac.warwick.tabula.api.web.controllers.ApiController
 import uk.ac.warwick.tabula.api.web.controllers.groups.ModuleSmallGroupSetsController._
-import uk.ac.warwick.tabula.api.web.helpers.{AssessmentMembershipInfoToJsonConverter, SmallGroupEventToJsonConverter, SmallGroupSetToJsonConverter, SmallGroupToJsonConverter}
+import uk.ac.warwick.tabula.api.web.helpers.{AssessmentMembershipInfoToJsonConverter, SmallGroupAttendanceToJsonConverter, SmallGroupEventToJsonConverter, SmallGroupSetToJsonConverter, SmallGroupToJsonConverter}
 import uk.ac.warwick.tabula.commands.Appliable
 import uk.ac.warwick.tabula.commands.groups.admin.{AdminSmallGroupsHomeCommand, _}
 import uk.ac.warwick.tabula.data.model._
@@ -36,6 +35,7 @@ abstract class ModuleSmallGroupSetsController extends ApiController
   with SmallGroupSetToJsonConverter
   with SmallGroupToJsonConverter
   with SmallGroupEventToJsonConverter
+  with SmallGroupAttendanceToJsonConverter
   with AssessmentMembershipInfoToJsonConverter {
 
   hideDeletedItems

--- a/api/src/main/scala/uk/ac/warwick/tabula/api/web/controllers/groups/SmallGroupController.scala
+++ b/api/src/main/scala/uk/ac/warwick/tabula/api/web/controllers/groups/SmallGroupController.scala
@@ -2,7 +2,6 @@ package uk.ac.warwick.tabula.api.web.controllers.groups
 
 import javax.servlet.http.HttpServletResponse
 import javax.validation.Valid
-
 import org.springframework.http.{HttpStatus, MediaType}
 import org.springframework.stereotype.Controller
 import org.springframework.validation.Errors
@@ -10,6 +9,7 @@ import org.springframework.web.bind.annotation._
 import uk.ac.warwick.tabula.JavaImports._
 import uk.ac.warwick.tabula.api.commands.JsonApiRequest
 import uk.ac.warwick.tabula.api.web.controllers.groups.SmallGroupController.{DeleteSmallGroupCommand, ModifySmallGroupCommand}
+import uk.ac.warwick.tabula.commands.groups.ViewSmallGroupAttendanceCommand
 import uk.ac.warwick.tabula.commands.{Appliable, ViewViewableCommand}
 import uk.ac.warwick.tabula.commands.groups.admin._
 import uk.ac.warwick.tabula.data.model._
@@ -49,6 +49,33 @@ trait GetSmallGroupApi {
         "success" -> true,
         "status" -> "ok",
         "group" -> jsonSmallGroupObject(result)
+      )))
+    }
+  }
+}
+
+@Controller
+@RequestMapping(Array("/v1/groups/{smallGroup}/attendance"))
+class SmallGroupAttendanceController extends SmallGroupSetController with ViewSmallGroupAttendanceApi
+
+trait ViewSmallGroupAttendanceApi {
+  self: SmallGroupSetController =>
+
+  @ModelAttribute("getCommand")
+  def getCommand(@PathVariable smallGroup: SmallGroup): ViewSmallGroupAttendanceCommand.Command =
+    ViewSmallGroupAttendanceCommand(mandatory(smallGroup))
+
+  @RequestMapping(method = Array(GET), produces = Array("application/json"))
+  def getIt(@Valid @ModelAttribute("getCommand") command: ViewSmallGroupAttendanceCommand.Command, errors: Errors, @PathVariable smallGroup: SmallGroup): Mav = {
+    // Return the GET representation
+    if (errors.hasErrors) {
+      Mav(new JSONErrorView(errors))
+    } else {
+      val result = command.apply()
+      Mav(new JSONView(Map(
+        "success" -> true,
+        "status" -> "ok",
+        "attendance" -> jsonSmallGroupAttendanceObject(result)
       )))
     }
   }

--- a/api/src/main/scala/uk/ac/warwick/tabula/api/web/helpers/SmallGroupAttendanceToJsonConverter.scala
+++ b/api/src/main/scala/uk/ac/warwick/tabula/api/web/helpers/SmallGroupAttendanceToJsonConverter.scala
@@ -1,0 +1,86 @@
+package uk.ac.warwick.tabula.api.web.helpers
+
+import uk.ac.warwick.tabula.DateFormats
+
+import scala.jdk.CollectionConverters._
+import uk.ac.warwick.tabula.commands.groups.ViewSmallGroupAttendanceCommand.SmallGroupAttendanceInformation
+import uk.ac.warwick.tabula.data.model.groups.SmallGroupEventOccurrence.WeekNumber
+import uk.ac.warwick.tabula.data.model.groups.{SmallGroupEvent, SmallGroupEventAttendance, SmallGroupEventAttendanceNote, SmallGroupEventOccurrence}
+
+import scala.collection.{SortedMap, mutable}
+
+trait SmallGroupAttendanceToJsonConverter {
+  self: SmallGroupEventToJsonConverter =>
+
+  def jsonSmallGroupEventWithWeekObject(eventWithWeek: (SmallGroupEvent, SmallGroupEventOccurrence.WeekNumber)): (String, Map[String, Any]) = {
+    eventWithWeek match {
+      case (event, _) => event.id -> jsonSmallGroupEventObject(event)
+    }
+  }
+
+  def jsonSmallGroupEventWithWeekRefObject(eventWithWeek: (SmallGroupEvent, SmallGroupEventOccurrence.WeekNumber)): Map[String, Any] = {
+    eventWithWeek match {
+      case (event, week) => Map(
+        "week" -> week,
+        "event" -> event.id
+      )
+    }
+  }
+
+  def jsonSmallGroupEventAttendanceObject(attendance: SmallGroupEventAttendance): Map[String, Any] = {
+    Map(
+      "updatedDate" -> DateFormats.IsoDate.print(attendance.updatedDate),
+      "updatedBy" -> attendance.updatedBy,
+      "joinedOn" -> Option(attendance.joinedOn).map(DateFormats.IsoDate.print).orNull,
+      "expectedToAttend" -> attendance.expectedToAttend,
+      "addedManually" -> attendance.addedManually,
+      "replacesAttendance" -> Option(attendance.replacesAttendance).map(jsonSmallGroupEventAttendanceObject).orNull,
+      "replacedBy" -> attendance.replacedBy.asScala.map(jsonSmallGroupEventAttendanceObject)
+    )
+  }
+
+  def jsonSmallGroupEventAttendanceNoteObject(note: SmallGroupEventAttendanceNote): Map[String, Any] = {
+    Map(
+      "comment" -> note.note,
+      "updatedBy" -> note.updatedBy,
+      "updatedDate" -> DateFormats.IsoDate.print(note.updatedDate),
+      "attachment" -> Option(note.attachment).map(_.id).orNull,
+      "absenceType" -> note.absenceType.description
+    )
+  }
+
+  def jsonSmallGroupAttendanceObject(group: SmallGroupAttendanceInformation): Map[String, Any] = {
+    val events: SortedMap[String, Any] = SortedMap(group.instances.map{ case (event, _) =>
+      event.id -> jsonSmallGroupEventObject(event)} : _*);
+    val notes: Map[String, Map[(String, WeekNumber), Map[String, Any]]] = group.notes.map{ case (user, userNotes) =>
+      user.getWarwickId -> userNotes.map{ case (eventWithWeek, note) =>
+        (eventWithWeek._1.id, eventWithWeek._2) -> jsonSmallGroupEventAttendanceNoteObject(note) }};
+    var instances: mutable.Map[String, mutable.Set[WeekNumber]] = mutable.Map();
+
+    group.instances.foreach { case (event, weekNumber) => {
+        val set: Option[mutable.Set[WeekNumber]] = instances.get(event.id);
+        set match {
+          case None => instances.addOne(event.id, mutable.Set(weekNumber))
+          case Some(v) => v.addOne(weekNumber)
+        }
+    }};
+
+    Map(
+      "events" -> events,
+      "instances" -> instances,
+      "attendance" -> group.attendance.map { case (user, events) =>
+        Map(
+          "student" -> user.getWarwickId,
+          "events" -> events.map { case (eventWithWeek, attendanceStatus) => Map(
+            "event" -> jsonSmallGroupEventWithWeekRefObject(eventWithWeek),
+            "status" -> Map(
+              "state" -> attendanceStatus._1.getName,
+              "details" -> attendanceStatus._2.map(jsonSmallGroupEventAttendanceObject).orNull,
+              "note" -> notes.get(user.getWarwickId).map(userNotes =>
+                userNotes.get((eventWithWeek._1.id, eventWithWeek._2)).orNull).orNull
+            )
+          ) })
+      }
+    )
+  }
+}


### PR DESCRIPTION
This PR adds a new API endpoint to retrieve small group attendance, comparable in behaviour to the UI at `/groups/group/:smallGroupId/attendance`. For example
```bash
$ curl -XGET https://tabula.warwick.ac.uk/api/v1/groups/:smallGroupId/attendance
```
would result in a response in the following format:
```javascript
{
    "success": true,
    "status": "ok",
    "attendance": {
        "events": {
            "86d7b5a4-d5b9-44e8-b61c-86d1f1952517": {
                "weeks": [
                    {
                        "minWeek": 1,
                        "maxWeek": 10
                    }
                ],
                "endTime": "14:00",
                "id": "86d7b5a4-d5b9-44e8-b61c-86d1f1952517",
                "title": "Lab",
                "startTime": "13:00",
                "location": {
                    "name": "CS0.01",
                    "locationId": "26811",
                    "syllabusPlusName": ""
                },
                "tutors": [
                    {
                        "userId": "u1672682",
                        "universityId": "1672682"
                    }
                ],
                "day": "Monday"
            }
        },
        "instances": {
            "86d7b5a4-d5b9-44e8-b61c-86d1f1952517": 
               [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
        },
        "attendance": [
            {
                "student": "1510654",
                "events": [
                    {
                        "event": {
                            "week": 1,
                            "event": "86d7b5a4-d5b9-44e8-b61c-86d1f1952517"
                        },
                        "status": {
                            "state": "Late",
                            "details": null,
                            "note": null
                        }
                    },
                    {
                        "event": {
                            "week": 2,
                            "event": "86d7b5a4-d5b9-44e8-b61c-86d1f1952517"
                        },
                        "status": {
                            "state": "MissedAuthorised",
                            "details": {
                                "replacedBy": [],
                                "replacesAttendance": null,
                                "joinedOn": null,
                                "addedManually": false,
                                "expectedToAttend": true,
                                "updatedBy": "u1673477",
                                "updatedDate": "2020-02-18"
                            },
                            "note": {
                                "absenceType": "Change of study location",
                                "comment": "No XSS attacks were attempted from Kenilworth",
                                "attachment": null,
                                "updatedBy": "u1673477",
                                "updatedDate": "2020-02-18"
                            }
                        }
                    },
                    // a lot more events
                ]
            }
        ]
    }
}
```