### PR TITLE
Multiple improvements in attendance APIs

### DIFF
--- a/api/src/main/scala/uk/ac/warwick/tabula/api/web/controllers/groups/ModuleSmallGroupSetsController.scala
+++ b/api/src/main/scala/uk/ac/warwick/tabula/api/web/controllers/groups/ModuleSmallGroupSetsController.scala
@@ -11,7 +11,7 @@ import uk.ac.warwick.tabula.JavaImports._
 import uk.ac.warwick.tabula.api.commands.JsonApiRequest
 import uk.ac.warwick.tabula.api.web.controllers.ApiController
 import uk.ac.warwick.tabula.api.web.controllers.groups.ModuleSmallGroupSetsController._
-import uk.ac.warwick.tabula.api.web.helpers.{AssessmentMembershipInfoToJsonConverter, SmallGroupAttendanceToJsonConverter, SmallGroupEventToJsonConverter, SmallGroupSetToJsonConverter, SmallGroupToJsonConverter}
+import uk.ac.warwick.tabula.api.web.helpers.{AssessmentMembershipInfoToJsonConverter, FileAttachmentToJsonConverter, SmallGroupAttendanceToJsonConverter, SmallGroupEventAttendanceNoteToJsonConverter, SmallGroupEventToJsonConverter, SmallGroupSetToJsonConverter, SmallGroupToJsonConverter}
 import uk.ac.warwick.tabula.commands.Appliable
 import uk.ac.warwick.tabula.commands.groups.admin.{AdminSmallGroupsHomeCommand, _}
 import uk.ac.warwick.tabula.data.model._
@@ -36,7 +36,9 @@ abstract class ModuleSmallGroupSetsController extends ApiController
   with SmallGroupToJsonConverter
   with SmallGroupEventToJsonConverter
   with SmallGroupAttendanceToJsonConverter
-  with AssessmentMembershipInfoToJsonConverter {
+  with AssessmentMembershipInfoToJsonConverter
+  with SmallGroupEventAttendanceNoteToJsonConverter
+  with FileAttachmentToJsonConverter {
 
   hideDeletedItems
 

--- a/api/src/main/scala/uk/ac/warwick/tabula/api/web/helpers/SmallGroupAttendanceToJsonConverter.scala
+++ b/api/src/main/scala/uk/ac/warwick/tabula/api/web/helpers/SmallGroupAttendanceToJsonConverter.scala
@@ -10,7 +10,7 @@ import uk.ac.warwick.tabula.data.model.groups.{SmallGroupEvent, SmallGroupEventA
 import scala.collection.{SortedMap, mutable}
 
 trait SmallGroupAttendanceToJsonConverter {
-  self: SmallGroupEventToJsonConverter =>
+  self: SmallGroupEventToJsonConverter with SmallGroupEventAttendanceNoteToJsonConverter =>
 
   def jsonSmallGroupEventWithWeekObject(eventWithWeek: (SmallGroupEvent, SmallGroupEventOccurrence.WeekNumber)): (String, Map[String, Any]) = {
     eventWithWeek match {
@@ -34,18 +34,9 @@ trait SmallGroupAttendanceToJsonConverter {
       "joinedOn" -> Option(attendance.joinedOn).map(DateFormats.IsoDate.print).orNull,
       "expectedToAttend" -> attendance.expectedToAttend,
       "addedManually" -> attendance.addedManually,
-      "replacesAttendance" -> Option(attendance.replacesAttendance).map(jsonSmallGroupEventAttendanceObject).orNull,
+      "replacesAttendance" -> Option(attendance.replacesAttendance).map(replaced =>
+        jsonSmallGroupEventWithWeekRefObject((replaced.occurrence.event, replaced.occurrence.week))).orNull,
       "replacedBy" -> attendance.replacedBy.asScala.map(jsonSmallGroupEventAttendanceObject)
-    )
-  }
-
-  def jsonSmallGroupEventAttendanceNoteObject(note: SmallGroupEventAttendanceNote): Map[String, Any] = {
-    Map(
-      "comment" -> note.note,
-      "updatedBy" -> note.updatedBy,
-      "updatedDate" -> DateFormats.IsoDateTime.print(note.updatedDate),
-      "attachment" -> Option(note.attachment).map(_.id).orNull,
-      "absenceType" -> note.absenceType.description
     )
   }
 
@@ -76,12 +67,10 @@ trait SmallGroupAttendanceToJsonConverter {
           "student" -> user.getWarwickId,
           "events" -> events.map { case (eventWithWeek, attendanceStatus) => Map(
             "event" -> jsonSmallGroupEventWithWeekRefObject(eventWithWeek),
-            "status" -> Map(
-              "state" -> attendanceStatus._1.getName,
-              "details" -> attendanceStatus._2.map(jsonSmallGroupEventAttendanceObject).orNull,
-              "note" -> notes.get(user.getWarwickId).map(userNotes =>
-                userNotes.get((eventWithWeek._1.id, eventWithWeek._2)).orNull).orNull
-            )
+            "state" -> attendanceStatus._1.getName,
+            "details" -> attendanceStatus._2.map(jsonSmallGroupEventAttendanceObject).orNull,
+            "note" -> notes.get(user.getWarwickId).map(userNotes =>
+              userNotes.get((eventWithWeek._1.id, eventWithWeek._2)).orNull).orNull
           )
           })
       }

--- a/api/src/main/scala/uk/ac/warwick/tabula/api/web/helpers/SmallGroupAttendanceToJsonConverter.scala
+++ b/api/src/main/scala/uk/ac/warwick/tabula/api/web/helpers/SmallGroupAttendanceToJsonConverter.scala
@@ -22,7 +22,7 @@ trait SmallGroupAttendanceToJsonConverter {
     eventWithWeek match {
       case (event, week) => Map(
         "week" -> week,
-        "event" -> event.id
+        "id" -> event.id
       )
     }
   }
@@ -43,7 +43,7 @@ trait SmallGroupAttendanceToJsonConverter {
     Map(
       "comment" -> note.note,
       "updatedBy" -> note.updatedBy,
-      "updatedDate" -> DateFormats.IsoDate.print(note.updatedDate),
+      "updatedDate" -> DateFormats.IsoDateTime.print(note.updatedDate),
       "attachment" -> Option(note.attachment).map(_.id).orNull,
       "absenceType" -> note.absenceType.description
     )

--- a/api/src/main/scala/uk/ac/warwick/tabula/api/web/helpers/SmallGroupEventAttendanceNoteToJsonConverter.scala
+++ b/api/src/main/scala/uk/ac/warwick/tabula/api/web/helpers/SmallGroupEventAttendanceNoteToJsonConverter.scala
@@ -1,0 +1,18 @@
+package uk.ac.warwick.tabula.api.web.helpers
+
+import uk.ac.warwick.tabula.DateFormats
+import uk.ac.warwick.tabula.data.model.groups.SmallGroupEventAttendanceNote
+
+trait SmallGroupEventAttendanceNoteToJsonConverter {
+  self: FileAttachmentToJsonConverter =>
+
+  def jsonSmallGroupEventAttendanceNoteObject(note: SmallGroupEventAttendanceNote): Map[String, Any] = {
+    Map(
+      "absenceType" -> note.absenceType.dbValue,
+      "contents" -> note.note,
+      "updatedDate" -> DateFormats.IsoDateTime.print(note.updatedDate),
+      "updatedBy" -> note.updatedBy,
+      "attachment" -> Option(note.attachment).map(_.id).orNull,
+    ) ++ (if (Option(note.attachment).nonEmpty) Map("attachment" -> jsonFileAttachmentObject(note.attachment)) else Map())
+  }
+}

--- a/api/src/main/scala/uk/ac/warwick/tabula/api/web/helpers/SmallGroupEventAttendanceNoteToJsonConverter.scala
+++ b/api/src/main/scala/uk/ac/warwick/tabula/api/web/helpers/SmallGroupEventAttendanceNoteToJsonConverter.scala
@@ -11,8 +11,7 @@ trait SmallGroupEventAttendanceNoteToJsonConverter {
       "absenceType" -> note.absenceType.dbValue,
       "contents" -> note.note,
       "updatedDate" -> DateFormats.IsoDateTime.print(note.updatedDate),
-      "updatedBy" -> note.updatedBy,
-      "attachment" -> Option(note.attachment).map(_.id).orNull,
+      "updatedBy" -> note.updatedBy
     ) ++ (if (Option(note.attachment).nonEmpty) Map("attachment" -> jsonFileAttachmentObject(note.attachment)) else Map())
   }
 }

--- a/api/src/main/scala/uk/ac/warwick/tabula/api/web/helpers/SmallGroupEventAttendanceNoteToJsonConverter.scala
+++ b/api/src/main/scala/uk/ac/warwick/tabula/api/web/helpers/SmallGroupEventAttendanceNoteToJsonConverter.scala
@@ -9,6 +9,7 @@ trait SmallGroupEventAttendanceNoteToJsonConverter {
   def jsonSmallGroupEventAttendanceNoteObject(note: SmallGroupEventAttendanceNote): Map[String, Any] = {
     Map(
       "absenceType" -> note.absenceType.dbValue,
+      "absenceTypeDescription" -> note.absenceType.description,
       "contents" -> note.note,
       "updatedDate" -> DateFormats.IsoDateTime.print(note.updatedDate),
       "updatedBy" -> note.updatedBy


### PR DESCRIPTION
This PR does the following:
* Introduces a new `SmallGroupEventAttendanceNoteToJsonConverter` trait which moves the code used to format `SmallGroupEventAttendanceNote` values out of both `SmallGroupAttendanceToJsonConverter` and `StudentGroupAttendanceToJsonConverter`. The naming previously used by `StudentGroupAttendanceToJsonConverter` is maintained.
* `StudentGroupAttendanceToJsonConverter` now uses `SmallGroupEventToJsonConverter`, which adds slightly more information to the resulting objects since `jsonSmallGroupEventObject` includes the `weekRanges`, which the code in `studentGroupAttendanceAsJson` previously did not include
* `SmallGroupEventAttendanceNoteToJsonConverter` fixes a bug with `StudentGroupAttendanceToJsonConverter`'s old code which incorrectly formatted attendance notes as arrays of arrays.
* Fixes a logic error in the `jsonSmallGroupEventAttendanceObject` function in `SmallGroupAttendanceToJsonConverter` which resulted in a stack overflow due to the cyclic nature of `replacesAttendance` and `replacedBy`. The `"replacesAttendance"` field is now only populated with event references.
* Removes one unnecessary object layer in the JSON objects returned by `jsonSmallGroupAttendanceObject`.