### PR TITLE
Add API endpoint to retrieve the current academic year

### DIFF
--- a/api/src/main/scala/uk/ac/warwick/tabula/api/web/controllers/timetables/AcademicYearController.scala
+++ b/api/src/main/scala/uk/ac/warwick/tabula/api/web/controllers/timetables/AcademicYearController.scala
@@ -1,0 +1,20 @@
+package uk.ac.warwick.tabula.api.web.controllers.timetables
+
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.RequestMapping
+import uk.ac.warwick.tabula.AcademicYear
+import uk.ac.warwick.tabula.api.web.controllers.ApiController
+import uk.ac.warwick.tabula.web.Mav
+import uk.ac.warwick.tabula.web.views.JSONView
+
+@Controller
+@RequestMapping(Array("/v1/academicyear"))
+class AcademicYearController extends ApiController {
+  @RequestMapping(method = Array(GET), produces = Array("application/json"))
+  def list(): Mav =
+    Mav(new JSONView(Map(
+      "success" -> true,
+      "status" -> "ok",
+      "academicYear" -> AcademicYear.now().toString()
+    )))
+}

--- a/api/src/main/webapp/WEB-INF/filters-context.xml
+++ b/api/src/main/webapp/WEB-INF/filters-context.xml
@@ -25,6 +25,7 @@
       <excluded-url-pattern>/v1/department/*/modules</excluded-url-pattern>
       <excluded-url-pattern>/v1/module/*/occurrences/*</excluded-url-pattern>
       <excluded-url-pattern>/v1/relationships</excluded-url-pattern>
+      <excluded-url-pattern>/v1/academicyear</excluded-url-pattern>
       <excluded-url-pattern>/v1/termdates</excluded-url-pattern>
       <excluded-url-pattern>/v1/termdates.*</excluded-url-pattern>
       <excluded-url-pattern>/v1/termdates/*</excluded-url-pattern>


### PR DESCRIPTION
This PR adds a very simple API endpoint for retrieving the current academic year, e.g.

```
GET /v1/academicyear
{
    "success": true,
    "status": "ok",
    "academicYear": "19/20"
}
```

This is useful for other API endpoints which require an academic year as argument and where it often makes sense to specify the current academic year. 