### PR TITLE
Add universityIds parameter to module students API

### DIFF
--- a/api/src/main/scala/uk/ac/warwick/tabula/api/web/controllers/profiles/ModuleStudentsController.scala
+++ b/api/src/main/scala/uk/ac/warwick/tabula/api/web/controllers/profiles/ModuleStudentsController.scala
@@ -29,11 +29,11 @@ trait GetModuleStudentsApi {
   @RequestMapping(method = Array(GET), produces = Array("application/json"))
   def currentSITSAcademicYear(@ModelAttribute("getCommand") cmd: ViewViewableCommand[Module]): Mav = {
     getMav(
-      cmd.apply(),
-      AcademicYear.now(),
-      None,
-      None,
-      false
+      module = cmd.apply(),
+      academicYear = AcademicYear.now(),
+      endDate = None,
+      occurrence = None,
+      universityIds = false
     )
   }
 
@@ -43,16 +43,22 @@ trait GetModuleStudentsApi {
     @PathVariable academicYear: AcademicYear,
     @RequestParam(required = false) endDate: LocalDate,
     @RequestParam(required = false) occurrence: String,
-    @RequestParam(required = false) universityIds: Boolean
+    @RequestParam(required = false) universityIds: Boolean = false
   ): Mav = {
-    getMav(cmd.apply(), academicYear, Option(endDate), Option(occurrence), Option(universityIds).getOrElse(false))
+    getMav(
+      module = cmd.apply(),
+      academicYear = academicYear,
+      endDate = Option(endDate),
+      occurrence = Option(occurrence),
+      universityIds = universityIds
+    )
   }
 
   def getMav(module: Module, academicYear: AcademicYear, endDate: Option[LocalDate], occurrence: Option[String], universityIds: Boolean): Mav = {
-    val results = moduleRegistrationService.findRegisteredUsercodes(module, academicYear, endDate, occurrence)
+    val results = moduleRegistrationService.findRegisteredUsercodes(module, academicYear, endDate, occurrence, universityIds)
     Mav(new JSONView(Map(
       "success" -> true,
       "status" -> "ok"
-    ) ++ (if (universityIds) { Map("universityIds" -> results.map(_._2)) } else { Map ("usercodes" -> results.map(_._1)) })))
+    ) ++ (if (universityIds) { Map("universityIds" -> results) } else { Map ("usercodes" -> results) })))
   }
 }

--- a/api/src/main/scala/uk/ac/warwick/tabula/api/web/controllers/profiles/ModuleStudentsController.scala
+++ b/api/src/main/scala/uk/ac/warwick/tabula/api/web/controllers/profiles/ModuleStudentsController.scala
@@ -32,7 +32,8 @@ trait GetModuleStudentsApi {
       cmd.apply(),
       AcademicYear.now(),
       None,
-      None
+      None,
+      false
     )
   }
 
@@ -41,17 +42,17 @@ trait GetModuleStudentsApi {
     @ModelAttribute("getCommand") cmd: ViewViewableCommand[Module],
     @PathVariable academicYear: AcademicYear,
     @RequestParam(required = false) endDate: LocalDate,
-    @RequestParam(required = false) occurrence: String
+    @RequestParam(required = false) occurrence: String,
+    @RequestParam(required = false) universityIds: Boolean
   ): Mav = {
-    getMav(cmd.apply(), academicYear, Option(endDate), Option(occurrence))
+    getMav(cmd.apply(), academicYear, Option(endDate), Option(occurrence), Option(universityIds).getOrElse(false))
   }
 
-  def getMav(module: Module, academicYear: AcademicYear, endDate: Option[LocalDate], occurrence: Option[String]): Mav = {
-    val usercodes = moduleRegistrationService.findRegisteredUsercodes(module, academicYear, endDate, occurrence)
+  def getMav(module: Module, academicYear: AcademicYear, endDate: Option[LocalDate], occurrence: Option[String], universityIds: Boolean): Mav = {
+    val results = moduleRegistrationService.findRegisteredUsercodes(module, academicYear, endDate, occurrence)
     Mav(new JSONView(Map(
       "success" -> true,
-      "status" -> "ok",
-      "usercodes" -> usercodes
-    )))
+      "status" -> "ok"
+    ) ++ (if (universityIds) { Map("universityIds" -> results.map(_._2)) } else { Map ("usercodes" -> results.map(_._1)) })))
   }
 }

--- a/common/src/main/scala/uk/ac/warwick/tabula/data/ModuleRegistrationDao.scala
+++ b/common/src/main/scala/uk/ac/warwick/tabula/data/ModuleRegistrationDao.scala
@@ -43,7 +43,7 @@ trait ModuleRegistrationDao {
 
   def findCoreRequiredModules(route: Route, academicYear: AcademicYear, yearOfStudy: Int): Seq[CoreRequiredModule]
 
-  def findRegisteredUsercodes(module: Module, academicYear: AcademicYear, endDate: Option[LocalDate], occurrence: Option[String]): Seq[String]
+  def findRegisteredUsers(module: Module, academicYear: AcademicYear, endDate: Option[LocalDate], occurrence: Option[String]): Seq[(String, String)]
 
   def getByRecordedAssessmentComponentStudentsNeedsWritingToSits: Seq[ModuleRegistration]
 }
@@ -145,10 +145,10 @@ class ModuleRegistrationDaoImpl extends ModuleRegistrationDao with Daoisms {
       .seq
   }
 
-  def findRegisteredUsercodes(module: Module, academicYear: AcademicYear, endDate: Option[LocalDate], occurrence: Option[String]): Seq[String] = {
-    val query = session.newQuery[String](
+  def findRegisteredUsers(module: Module, academicYear: AcademicYear, endDate: Option[LocalDate], occurrence: Option[String]): Seq[(String, String)] = {
+    val query = session.newQuery[(String, String)](
       s"""
-        select distinct studentCourseDetails.student.userId
+        select distinct studentCourseDetails.student.userId, studentCourseDetails.student.universityId
         from ModuleRegistration mr
         join StudentCourseDetails studentCourseDetails
           on studentCourseDetails.sprCode = mr.sprCode

--- a/common/src/main/scala/uk/ac/warwick/tabula/data/ModuleRegistrationDao.scala
+++ b/common/src/main/scala/uk/ac/warwick/tabula/data/ModuleRegistrationDao.scala
@@ -43,7 +43,7 @@ trait ModuleRegistrationDao {
 
   def findCoreRequiredModules(route: Route, academicYear: AcademicYear, yearOfStudy: Int): Seq[CoreRequiredModule]
 
-  def findRegisteredUsers(module: Module, academicYear: AcademicYear, endDate: Option[LocalDate], occurrence: Option[String]): Seq[(String, String)]
+  def findRegisteredUsers(module: Module, academicYear: AcademicYear, endDate: Option[LocalDate], occurrence: Option[String], includeUniversityIds: Boolean): Seq[String]
 
   def getByRecordedAssessmentComponentStudentsNeedsWritingToSits: Seq[ModuleRegistration]
 }
@@ -145,10 +145,10 @@ class ModuleRegistrationDaoImpl extends ModuleRegistrationDao with Daoisms {
       .seq
   }
 
-  def findRegisteredUsers(module: Module, academicYear: AcademicYear, endDate: Option[LocalDate], occurrence: Option[String]): Seq[(String, String)] = {
-    val query = session.newQuery[(String, String)](
+  def findRegisteredUsers(module: Module, academicYear: AcademicYear, endDate: Option[LocalDate], occurrence: Option[String], universityIds: Boolean = false): Seq[String] = {
+    val query = session.newQuery[String](
       s"""
-        select distinct studentCourseDetails.student.userId, studentCourseDetails.student.universityId
+        select distinct ${if (universityIds) "studentCourseDetails.student.universityId" else "studentCourseDetails.student.userId"}
         from ModuleRegistration mr
         join StudentCourseDetails studentCourseDetails
           on studentCourseDetails.sprCode = mr.sprCode

--- a/common/src/main/scala/uk/ac/warwick/tabula/services/ModuleRegistrationService.scala
+++ b/common/src/main/scala/uk/ac/warwick/tabula/services/ModuleRegistrationService.scala
@@ -74,7 +74,7 @@ trait ModuleRegistrationService {
 
   def findCoreRequiredModules(route: Route, academicYear: AcademicYear, yearOfStudy: Int): Seq[CoreRequiredModule]
 
-  def findRegisteredUsercodes(module: Module, academicYear: AcademicYear, endDate: Option[LocalDate], occurrence: Option[String]): Seq[(String, String)]
+  def findRegisteredUsercodes(module: Module, academicYear: AcademicYear, endDate: Option[LocalDate], occurrence: Option[String], includeUniversityIds: Boolean): Seq[String]
 
 }
 
@@ -254,8 +254,8 @@ abstract class AbstractModuleRegistrationService extends ModuleRegistrationServi
   def findCoreRequiredModules(route: Route, academicYear: AcademicYear, yearOfStudy: Int): Seq[CoreRequiredModule] =
     moduleRegistrationDao.findCoreRequiredModules(route, academicYear, yearOfStudy)
 
-  def findRegisteredUsercodes(module: Module, academicYear: AcademicYear, endDate: Option[LocalDate], occurrence: Option[String]): Seq[(String, String)] =
-    moduleRegistrationDao.findRegisteredUsers(module, academicYear, endDate, occurrence)
+  def findRegisteredUsercodes(module: Module, academicYear: AcademicYear, endDate: Option[LocalDate], occurrence: Option[String], includeUniversityIds: Boolean = false): Seq[String] =
+    moduleRegistrationDao.findRegisteredUsers(module, academicYear, endDate, occurrence, includeUniversityIds)
 
 }
 

--- a/common/src/main/scala/uk/ac/warwick/tabula/services/ModuleRegistrationService.scala
+++ b/common/src/main/scala/uk/ac/warwick/tabula/services/ModuleRegistrationService.scala
@@ -74,7 +74,7 @@ trait ModuleRegistrationService {
 
   def findCoreRequiredModules(route: Route, academicYear: AcademicYear, yearOfStudy: Int): Seq[CoreRequiredModule]
 
-  def findRegisteredUsercodes(module: Module, academicYear: AcademicYear, endDate: Option[LocalDate], occurrence: Option[String]): Seq[String]
+  def findRegisteredUsercodes(module: Module, academicYear: AcademicYear, endDate: Option[LocalDate], occurrence: Option[String]): Seq[(String, String)]
 
 }
 
@@ -254,8 +254,8 @@ abstract class AbstractModuleRegistrationService extends ModuleRegistrationServi
   def findCoreRequiredModules(route: Route, academicYear: AcademicYear, yearOfStudy: Int): Seq[CoreRequiredModule] =
     moduleRegistrationDao.findCoreRequiredModules(route, academicYear, yearOfStudy)
 
-  def findRegisteredUsercodes(module: Module, academicYear: AcademicYear, endDate: Option[LocalDate], occurrence: Option[String]): Seq[String] =
-    moduleRegistrationDao.findRegisteredUsercodes(module, academicYear, endDate, occurrence)
+  def findRegisteredUsercodes(module: Module, academicYear: AcademicYear, endDate: Option[LocalDate], occurrence: Option[String]): Seq[(String, String)] =
+    moduleRegistrationDao.findRegisteredUsers(module, academicYear, endDate, occurrence)
 
 }
 


### PR DESCRIPTION
This ~hack~ PR adds a new parameter to the `/v1/module/:module/students` endpoint which makes it return University IDs instead of usercodes. I am particularly unsure about the modified query and whether `DISTINCT studentCourseDetails.student.userId, studentCourseDetails.student.universityId` may alter its behaviour. It's also not particularly elegant - I considered adding a new method to `ModuleRegistrationDao` first, but @lol768 talked me out of it. 