### PR TITLE
Add academicYear to MemberSearchCommandRequest

### DIFF
--- a/api/src/main/scala/uk/ac/warwick/tabula/api/commands/profiles/MemberSearchCommand.scala
+++ b/api/src/main/scala/uk/ac/warwick/tabula/api/commands/profiles/MemberSearchCommand.scala
@@ -46,7 +46,7 @@ abstract class MemberSearchCommandInternal(override val departments: Seq[Departm
       throw new IllegalArgumentException("At least one filter value must be defined")
     }
 
-    val restrictions = buildRestrictions(user, departments, AcademicYear.now())
+    val restrictions = buildRestrictions(user, departments, academicYear)
 
     departments match {
       case Nil => profileService.findAllUserIdsByRestrictions(restrictions).distinct
@@ -70,6 +70,7 @@ trait MemberSearchCommandRequest extends RequiresPermissionsChecking with Permis
 
   val defaultOrder: Seq[Order] = Seq(asc("lastName"), asc("firstName"))
 
+  var academicYear: AcademicYear = AcademicYear.now()
   var sortOrder: JList[Order] = JArrayList()
   var courseTypes: JList[CourseType] = JArrayList()
   var specificCourseTypes: JList[SpecificCourseType] = JArrayList()


### PR DESCRIPTION
This adds a new parameter to https://warwick.ac.uk/services/its/servicessupport/web/tabula/api/member/search-for-members which allows the academic year to be specified (defaulting to the current academic year, as is the current behaviour). This functionality is already present in the Web UI, but was missing from the API. 

For example, the following would retrieve the first five students registered for CS141 in 18/19 whose home department is `cs`:
```
GET https://tabula.warwick.ac.uk/api/v1/members?modules=cs141&limit=5&department=cs&academicYear=2018
```