### PR TITLE
Include startUTC and endUTC in event occurrence objects

### DIFF
--- a/api/src/main/scala/uk/ac/warwick/tabula/api/web/helpers/EventOccurrenceToJsonConverter.scala
+++ b/api/src/main/scala/uk/ac/warwick/tabula/api/web/helpers/EventOccurrenceToJsonConverter.scala
@@ -1,5 +1,6 @@
 package uk.ac.warwick.tabula.api.web.helpers
 
+import org.joda.time.DateTimeZone
 import uk.ac.warwick.tabula.DateFormats
 import uk.ac.warwick.tabula.data.model.{AliasedMapLocation, MapLocation}
 import uk.ac.warwick.tabula.services.ProfileServiceComponent
@@ -16,7 +17,9 @@ trait EventOccurrenceToJsonConverter {
     "description" -> event.description,
     "eventType" -> event.eventType.displayName,
     "start" -> DateFormats.IsoDateTime.print(event.start),
+    "startDateTime" -> DateFormats.IsoDateTime.print(event.start.toDateTime(DateTimeZone.forID("Europe/London"))),
     "end" -> DateFormats.IsoDateTime.print(event.end),
+    "endDateTime" -> DateFormats.IsoDateTime.print(event.end.toDateTime(DateTimeZone.forID("Europe/London"))),
     "location" -> (event.location match {
       case Some(AliasedMapLocation(alias, MapLocation(_, locationId, syllabusPlusName))) => Map(
         "name" -> alias,


### PR DESCRIPTION
This modifies `jsonEventOccurrenceObject` to include two new fields: `"startUTC"` and `"endUTC"`. This makes it easier for API clients to reasonably deal with the start and end times / doesn't require clients to implement this. The values of the new fields are obtained by converting the start/end times to Europe/London time. 

If merged, the updated documentation for this should include a disclaimer that, while the conversion is probably fine for all real-world use cases, it could theoretically produce nonsensical results. 

Field names are chosen for backwards-compatibility. Ideally, the API would never return times in magic local time. 