### PR TITLE
Stop submitted formative assignments showing twice

### DIFF
--- a/common/src/main/scala/uk/ac/warwick/tabula/commands/cm2/CourseworkHomepageCommand.scala
+++ b/common/src/main/scala/uk/ac/warwick/tabula/commands/cm2/CourseworkHomepageCommand.scala
@@ -279,9 +279,9 @@ trait StudentAssignmentsSummary extends TaskBenchmarking {
   }
 
   lazy val studentCompletedAssignments: Seq[StudentAssignmentInformation] = benchmarkTask("Get past assignments") {
-    val lateFormativeAssignments = enrolledAssignments.filter(_.lateFormative).filterNot(_.publishFeedback)
+    val lateFormativeAssignments = enrolledAssignments.filter(lateFormative).filterNot(_.publishFeedback)
 
-    val submittedAwaitingFeedback = assignmentsWithSubmission.filterNot(_.lateFormative).filterNot(_.publishFeedback)
+    val submittedAwaitingFeedback = assignmentsWithSubmission.filterNot(lateFormative).filterNot(_.publishFeedback)
 
     (assignmentsWithFeedback ++ lateFormativeAssignments ++ submittedAwaitingFeedback)
       .map(enhance)

--- a/common/src/main/scala/uk/ac/warwick/tabula/commands/cm2/CourseworkHomepageCommand.scala
+++ b/common/src/main/scala/uk/ac/warwick/tabula/commands/cm2/CourseworkHomepageCommand.scala
@@ -279,7 +279,11 @@ trait StudentAssignmentsSummary extends TaskBenchmarking {
   }
 
   lazy val studentCompletedAssignments: Seq[StudentAssignmentInformation] = benchmarkTask("Get past assignments") {
-    (assignmentsWithFeedback ++ enrolledAssignments.filter(lateFormative).filterNot(_.publishFeedback) ++ assignmentsWithSubmission.filterNot(_.publishFeedback))
+    val lateFormativeAssignments = enrolledAssignments.filter(_.lateFormative).filterNot(_.publishFeedback)
+
+    val submittedAwaitingFeedback = assignmentsWithSubmission.filterNot(_.lateFormative).filterNot(_.publishFeedback)
+
+    (assignmentsWithFeedback ++ lateFormativeAssignments ++ submittedAwaitingFeedback)
       .map(enhance)
       .sortWith(hasEarlierEffectiveDate)
   }


### PR DESCRIPTION
This PR (hopefully) fixes submitted formative assignments appearing twice in the "Feedback Available" section after the deadline has passed (as below) by applying `.filterNot(_.lateFormative)` to the assignments that are submitted and pending feedback.

![screenshot-2020-10-04-124419](https://user-images.githubusercontent.com/34679874/95014626-01096a80-0640-11eb-803e-42375316b720.png)

I wasn't sure whether to combine the `filterNot`s, I left it but that's easily changed